### PR TITLE
Create excludeservice flag

### DIFF
--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -59,14 +59,13 @@ export class ThriftFileConverter {
     thriftPath: string,
     transformName: string => string,
     withsource: boolean,
-    includetypes: string,
+    excludeservice: boolean,
   ) {
     this.thriftPath = path.resolve(thriftPath);
     this.thrift = new Thrift({...thriftOptions, entryPoint: thriftPath});
     this.ast = this.thrift.asts[this.thrift.filename];
-    this.types = includetypes.split(',');
-    this.thriftAstDefinitions = this.types.length
-      ? this.ast.definitions.filter(def => this.types.indexOf(def.type) !== -1)
+    this.thriftAstDefinitions = excludeservice
+      ? this.ast.definitions.filter(def => def.type !== 'Service')
       : this.ast.definitions;
     this.transformName = transformName;
     this.types = new TypeConverter(transformName, this.thriftAstDefinitions);

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -58,12 +58,16 @@ export class ThriftFileConverter {
   constructor(
     thriftPath: string,
     transformName: string => string,
-    withsource: boolean
+    withsource: boolean,
+    includetypes: string,
   ) {
     this.thriftPath = path.resolve(thriftPath);
     this.thrift = new Thrift({...thriftOptions, entryPoint: thriftPath});
     this.ast = this.thrift.asts[this.thrift.filename];
-    this.thriftAstDefinitions = this.ast.definitions;
+    this.types = includetypes.split(',');
+    this.thriftAstDefinitions = this.types.length
+      ? this.ast.definitions.filter(def => this.types.indexOf(def.type) !== -1)
+      : this.ast.definitions;
     this.transformName = transformName;
     this.types = new TypeConverter(transformName, this.thriftAstDefinitions);
     this.withsource = withsource;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -50,10 +50,14 @@ const argv = yargs
     describe: 'prepend the source path of the thrift file',
     default: false,
   })
-  .option('includetypes', {
-    describe: 'only include given types (in comma separated list). if flag not used, then all types are generated. ' +
-      'options are: Struct, Exception, Union, Enum, Typedef, Service. ex: Struct,Exception,Union',
-    default: '',
+  // .option('includetypes', {
+  //   describe: 'only include given types (in comma separated list). if flag not used, then all types are generated. ' +
+  //     'options are: Struct, Exception, Union, Enum, Typedef, Service. ex: Struct,Exception,Union',
+  //   default: '',
+  // })
+  .option('excludeservice', {
+    describe: 'exclude service definitions',
+    default: false,
   })
   .help('h')
   .alias('h', 'help').argv;
@@ -72,7 +76,7 @@ for (const thriftPath of thriftPaths) {
     thriftPath,
     name => name + argv.suffix,
     argv.withsource,
-    argv.includetypes,
+    argv.excludeservice,
   );
   converter
     .getImportAbsPaths()

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -50,6 +50,11 @@ const argv = yargs
     describe: 'prepend the source path of the thrift file',
     default: false,
   })
+  .option('includetypes', {
+    describe: 'only include given types (in comma separated list). if flag not used, then all types are generated. ' +
+      'options are: Struct, Exception, Union, Enum, Typedef, Service. ex: Struct,Exception,Union',
+    default: '',
+  })
   .help('h')
   .alias('h', 'help').argv;
 
@@ -66,7 +71,8 @@ for (const thriftPath of thriftPaths) {
   const converter = new ThriftFileConverter(
     thriftPath,
     name => name + argv.suffix,
-    argv.withsource
+    argv.withsource,
+    argv.includetypes,
   );
   converter
     .getImportAbsPaths()

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -50,11 +50,6 @@ const argv = yargs
     describe: 'prepend the source path of the thrift file',
     default: false,
   })
-  // .option('includetypes', {
-  //   describe: 'only include given types (in comma separated list). if flag not used, then all types are generated. ' +
-  //     'options are: Struct, Exception, Union, Enum, Typedef, Service. ex: Struct,Exception,Union',
-  //   default: '',
-  // })
   .option('excludeservice', {
     describe: 'exclude service definitions',
     default: false,

--- a/src/test/flags.spec.js
+++ b/src/test/flags.spec.js
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Uber Node.js
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// @flow
+
+import test from 'tape';
+import type {Test} from 'tape';
+
+import {flowResultTest} from './util';
+
+// language=thrift
+const testThriftFile = `
+typedef MyEnum EnumTypedef
+
+enum MyEnum {
+  OK = 1
+  ERROR = 2
+}
+
+struct MyStruct {
+  1: MyEnum f_MyEnum
+  2: EnumTypedef f_EnumTypedef
+}
+`;
+
+test(
+  'enums',
+  flowResultTest(
+    {
+      'types.thrift': testThriftFile,
+      // language=JavaScript
+      'index.js': `
+// @flow
+import {MyEnumValueMap} from './types';
+import type {MyStructXXX,EnumTypedefXXX,MyEnumXXX} from './types';
+
+const ok: MyEnumXXX = 'OK';
+const error: MyEnumXXX = 'ERROR';
+
+const struct: MyStructXXX = {
+  f_MyEnum: ok,
+  f_EnumTypedef: error,
+}
+
+const okFromMap: 1 = MyEnumValueMap.OK;
+const errorFromMap: 2 = MyEnumValueMap.ERROR;
+
+const t: EnumTypedefXXX = ok;
+`,
+    },
+    (t: Test, r: FlowResult) => {
+      t.equal(r.errors.length, 0);
+      t.end();
+    },
+    'XXX',
+    true,
+    'Enum',
+  )
+);

--- a/src/test/index.spec.js
+++ b/src/test/index.spec.js
@@ -35,3 +35,4 @@ import './services.spec';
 import './enums.spec';
 import './unions.spec';
 import './consts.spec';
+import './flags.spec';

--- a/src/test/typedefs.spec.js
+++ b/src/test/typedefs.spec.js
@@ -102,7 +102,8 @@ struct UserActivitiesRequest {
       let output = new ThriftFileConverter(
         p,
         name => name,
-        true
+        true,
+        false,
       ).generateFlowFile();
 
       let longIndex = output.indexOf('import Long');
@@ -133,7 +134,8 @@ typedef i64 (js.type = "Long") Points
       let output = new ThriftFileConverter(
         p,
         name => name,
-        true
+        true,
+        false,
       ).generateFlowFile();
 
       let longIndex = output.indexOf('import Long');

--- a/src/test/util.js
+++ b/src/test/util.js
@@ -39,7 +39,7 @@ export const flowResultTest = (
   testFn: (Function, FlowResult) => void,
   suffix: string = 'XXX',
   withsource: boolean = true,
-  includetypes: string = '',
+  excludeservice: boolean = false
 ) => (t: Test) => {
   const root = path.resolve('test-output/', uuid());
   fs.mkdirSync(root);
@@ -61,7 +61,7 @@ export const flowResultTest = (
           p,
           name => name + suffix,
           withsource,
-          includetypes,
+          excludeservice,
         ).generateFlowFile()
       );
     });

--- a/src/test/util.js
+++ b/src/test/util.js
@@ -38,7 +38,8 @@ export const flowResultTest = (
   files: {[string]: string},
   testFn: (Function, FlowResult) => void,
   suffix: string = 'XXX',
-  withsource: boolean = true
+  withsource: boolean = true,
+  includetypes: string = '',
 ) => (t: Test) => {
   const root = path.resolve('test-output/', uuid());
   fs.mkdirSync(root);
@@ -59,7 +60,8 @@ export const flowResultTest = (
         new ThriftFileConverter(
           p,
           name => name + suffix,
-          withsource
+          withsource,
+          includetypes,
         ).generateFlowFile()
       );
     });


### PR DESCRIPTION
Create excludeservice flag. When set to true, thrift2flow skips flow/js generation for thrift service definitions.